### PR TITLE
fix windows paths handling

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -89,6 +89,10 @@ export default function native(options) {
   const filter = pluginutils.createFilter(options.include, options.exclude);
 
   function generateCode(filename, keys, format) {
+    //Convert the filename to use a forward slash separator so that backslashes
+    //aren't interpreted as escapes in the template literals below
+    filename = filename.replace(/\\/g,'/');
+
     switch (options.loaderMode) {
       case "dlopen":
         const formatSpecific =


### PR DESCRIPTION
* Replacing backslashes with forward slashes so that the backslashes aren't interpreted as escapes in template literals